### PR TITLE
Make world weapon API only use vectors.

### DIFF
--- a/include/bzfsAPI.h
+++ b/include/bzfsAPI.h
@@ -1037,7 +1037,7 @@ public:
   bz_ApiString flagType;
   float lifetime;
   float pos[3];
-  float lookAt[3];
+  float velocity[3];
   bz_eTeamType team;
 };
 
@@ -1630,23 +1630,27 @@ BZF_API bool bz_sendTextMessagef(int from, bz_eTeamType to, const char* fmt, ...
 BZF_API bool bz_sentFetchResMessage ( int playerID,  const char* URL );
 
 // world weapons
-DEPRECATED BZF_API bool bz_fireWorldWep ( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
-DEPRECATED BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, float speed, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
-DEPRECATED BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
-DEPRECATED BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam = eRogueTeam);
+// deprecated API, will be removed in next version
+BZF_API bool bz_fireWorldWep ( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
+BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, float speed, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
+BZF_API bool bz_fireWorldWep( const char* flagType, float lifetime, int fromPlayer, float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam = eRogueTeam );
+BZF_API int bz_fireWorldGM ( int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam = eRogueTeam);
 
-BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float lookAtVector[3], bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
-BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float tilt, float direction, bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
+// new server shot API
+BZF_API uint32_t bz_fireServerShot(const char* shotType, float origin[3], float vector[3], bz_eTeamType color = eRogueTeam, int targetPlayerId = -1);
 
-BZF_API const bz_ApiString bz_getShotMetaData(const uint32_t shotGUID, const char* name);
-BZF_API bool bz_hasShotMetaData(const uint32_t shotGUID, const char* name);
+BZF_API void bz_setShotMetaData (const uint32_t shotGUID, const char* name, uint32_t value);
 BZF_API void bz_setShotMetaData(const uint32_t shotGUID, const char* name, const char* value);
+BZF_API bool bz_shotHasMetaData (const uint32_t shotGUID, const char* name);
 
-BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name);
-BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, uint32_t value);
-BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name);
+BZF_API uint32_t bz_getShotMetaDataI(const uint32_t shotGUID, const char* name);
+BZF_API const char* bz_getShotMetaDataS(const uint32_t shotGUID, const char* name);
 
 BZF_API uint32_t bz_getShotGUID (int fromPlayer, int shotID);
+
+// geometry utils
+BZF_API bool bz_VectorFromPoints(const float p1[3], const float p2[3], float outVec[3]);
+BZF_API bool bz_VectorFromRotations(const float tilt, const float rotation, float outVec[3]);
 
 typedef struct {
   int year;

--- a/src/bzfs/GameKeeper.cxx
+++ b/src/bzfs/GameKeeper.cxx
@@ -370,6 +370,25 @@ void GameKeeper::Player::setMaxShots(int _maxShots)
   maxShots = _maxShots;
 }
 
+float GetShotLifetime(FlagType* flagType)
+{
+	float lifeTime(BZDB.eval(StateDatabase::BZDB_RELOADTIME));
+	if (flagType == Flags::RapidFire)
+		lifeTime *= BZDB.eval(StateDatabase::BZDB_RFIREADLIFE);
+	else if (flagType == Flags::MachineGun)
+		lifeTime *= BZDB.eval(StateDatabase::BZDB_MGUNADLIFE);
+	else if (flagType == Flags::GuidedMissile)
+		lifeTime *= BZDB.eval(StateDatabase::BZDB_GMADLIFE) + .01f;
+	else if (flagType == Flags::Laser)
+		lifeTime *= BZDB.eval(StateDatabase::BZDB_LASERADLIFE);
+	else if (flagType == Flags::ShockWave)
+		lifeTime *= BZDB.eval(StateDatabase::BZDB_SHOCKADLIFE);
+	else if (flagType == Flags::Thief)
+		lifeTime *= BZDB.eval(StateDatabase::BZDB_THIEFADLIFE);
+
+	return lifeTime;
+}
+
 bool GameKeeper::Player::addShot(int id, int salt, FiringInfo &firingInfo)
 {
   float now((float)TimeKeeper::getCurrent().getSeconds());
@@ -388,19 +407,7 @@ bool GameKeeper::Player::addShot(int id, int salt, FiringInfo &firingInfo)
 
   shotsInfo.resize(maxShots);
 
-  float lifeTime(BZDB.eval(StateDatabase::BZDB_RELOADTIME));
-  if (firingInfo.flagType == Flags::RapidFire)
-    lifeTime *= BZDB.eval(StateDatabase::BZDB_RFIREADLIFE);
-  else if (firingInfo.flagType == Flags::MachineGun)
-    lifeTime *= BZDB.eval(StateDatabase::BZDB_MGUNADLIFE);
-  else if (firingInfo.flagType == Flags::GuidedMissile)
-    lifeTime *= BZDB.eval(StateDatabase::BZDB_GMADLIFE) + .01f;
-  else if (firingInfo.flagType == Flags::Laser)
-    lifeTime *= BZDB.eval(StateDatabase::BZDB_LASERADLIFE);
-  else if (firingInfo.flagType == Flags::ShockWave)
-    lifeTime *= BZDB.eval(StateDatabase::BZDB_SHOCKADLIFE);
-  else if (firingInfo.flagType == Flags::Thief)
-    lifeTime *= BZDB.eval(StateDatabase::BZDB_THIEFADLIFE);
+  float lifeTime = GetShotLifetime(firingInfo.flagType);
 
   ShotInfo myShot;
   myShot.firingInfo  = firingInfo;

--- a/src/bzfs/ShotManager.cxx
+++ b/src/bzfs/ShotManager.cxx
@@ -227,6 +227,37 @@ namespace Shots
 	{
 	}
 
+	void Shot::SetMetaData(const std::string& name, const char* data)
+	{
+		if (MetaData.find(name) == MetaData.end())
+			MetaData[name] = MetaDataItem();
+		MetaData[name].DataS = data;
+	}
+
+	void Shot::SetMetaData(const std::string& name, uint32_t data)
+	{
+		if (MetaData.find(name) == MetaData.end())
+			MetaData[name] = MetaDataItem();
+		MetaData[name].DataI = data;
+	}
+
+	bool Shot::HasMetaData(const std::string& name)
+	{
+		return MetaData.find(name) != MetaData.end();
+	}
+
+	const char * Shot::GetMetaDataS(const std::string& name)
+	{
+		auto itr = MetaData.find(name);
+		return itr == MetaData.end() ? nullptr : itr->second.DataS.c_str();
+	}
+
+	uint32_t Shot::GetMetaDataI(const std::string& name)
+	{
+		auto itr = MetaData.find(name);
+		return itr == MetaData.end() ? 0 : itr->second.DataI;
+	}
+
 	bool Shot::Update()
 	{
 		if (Logic.Update(*this))

--- a/src/bzfs/ShotManager.h
+++ b/src/bzfs/ShotManager.h
@@ -67,14 +67,22 @@ protected:
 	FlightLogic &Logic;
 
 	double	LifeTime;
+
+	class MetaDataItem
+	{
+	public:
+		std::string Name;
+		std::string DataS;
+		uint32_t	DataI;
+	};
+
+	std::map<std::string, MetaDataItem> MetaData;
+
 public:
 	fvec3		StartPosition;
 	fvec3		LastUpdatePosition;
 	double		LastUpdateTime;
 	double		StartTime;
-
-	std::map<std::string, std::string> stringMetaData;
-	std::map<std::string, uint32_t> intMetaData;
 
 	FiringInfo	Info;
 
@@ -103,6 +111,14 @@ public:
 	bool CollideBox ( fvec3 &center, fvec3 size, float rotation ) {return Logic.CollideBox(*this,center,size,rotation);}
 	bool CollideSphere ( fvec3 &center, float radius ) {return Logic.CollideSphere(*this,center,radius);}
 	bool CollideCylinder ( fvec3 &center, float height, float radius) {return Logic.CollideCylinder(*this,center,height,radius);}
+
+	// meta data API
+	void SetMetaData(const std::string& name, const char* data);
+	void SetMetaData(const std::string& name, uint32_t data);
+	bool HasMetaData(const std::string& name);
+	const char * GetMetaDataS(const std::string& name);
+	uint32_t GetMetaDataI(const std::string& name);
+
 };
 
 typedef std::shared_ptr<Shot>	ShotRef;

--- a/src/bzfs/WorldWeapons.cxx
+++ b/src/bzfs/WorldWeapons.cxx
@@ -29,7 +29,7 @@
 #include "bzfs.h"
 #include "ShotManager.h"
 
-uint32_t WorldWeapons::fireShot(FlagType* type, float lifetime, float *pos, float tilt, float direction, float shotSpeed, int *shotID, float delayTime, TeamColor teamColor, PlayerId targetPlayerID)
+uint32_t WorldWeapons::fireShot(FlagType* type, float lifetime, const float origin[3], const float vector[3], float shotSpeed, int *shotID, float delayTime, TeamColor teamColor, PlayerId targetPlayerID)
 {
   if (!BZDB.isTrue(StateDatabase::BZDB_WEAPONS)) {
     return INVALID_SHOT_GUID;
@@ -42,23 +42,22 @@ uint32_t WorldWeapons::fireShot(FlagType* type, float lifetime, float *pos, floa
   firingInfo.flagType = type;
   firingInfo.lifetime = lifetime;
   firingInfo.shot.player = ServerPlayer;
-  memmove(firingInfo.shot.pos, pos, 3 * sizeof(float));
+  memmove(firingInfo.shot.pos, origin, 3 * sizeof(float));
 
   if (shotSpeed < 0)
     shotSpeed = BZDB.eval(StateDatabase::BZDB_SHOTSPEED);
-  const float tiltFactor = cosf(tilt);
 
-  firingInfo.shot.vel[0] = shotSpeed * tiltFactor * cosf(direction);
-  firingInfo.shot.vel[1] = shotSpeed * tiltFactor * sinf(direction);
-  firingInfo.shot.vel[2] = shotSpeed * sinf(tilt);
+  for (int i = 0; i < 3; i++)
+	  firingInfo.shot.vel[i] = vector[i] * shotSpeed;
+
   firingInfo.shot.dt = delayTime;
   firingInfo.shot.team = teamColor;
 
-  if (shotID != NULL && shotID == 0) {
+  if (shotID != nullptr && shotID == 0) {
     *shotID = getNewWorldShotID();
     firingInfo.shot.id = *shotID;
   }
-  else if (shotID == NULL) {
+  else if (shotID == nullptr) {
     firingInfo.shot.id = getNewWorldShotID();
   }
   else {
@@ -87,12 +86,10 @@ uint32_t WorldWeapons::fireShot(FlagType* type, float lifetime, float *pos, floa
   event.guid = shotGUID;
   event.flagType = type->flagAbbv;
   event.lifetime = lifetime;
-  event.pos[0] = pos[0];
-  event.pos[1] = pos[1];
-  event.pos[2] = pos[2];
-  event.lookAt[0] = cosf(direction);
-  event.lookAt[1] = sinf(direction);
-  event.lookAt[2] = sinf(tilt);
+  for (int i = 0; i < 3; i++){
+	  event.pos[i] = origin[i];
+	  event.velocity[i] = firingInfo.shot.vel[i];
+  }
   event.team = convertTeam(teamColor);
 
   WorldEventManager worldEventManager;
@@ -148,7 +145,9 @@ void WorldWeapons::fire()
     if (w->nextTime <= nowTime) {
       FlagType type = *(w->type);	// non-const copy
 
-      fireShot(&type, BZDB.eval(StateDatabase::BZDB_RELOADTIME), w->origin, w->tilt, w->direction, w->direction, NULL, 0, w->teamColor);
+	  float vec[3] = { 0,0,0 };
+	  bz_VectorFromRotations(w->tilt, w->direction, vec);
+      fireShot(&type, BZDB.eval(StateDatabase::BZDB_RELOADTIME), w->origin, vec, -1, nullptr, 0, w->teamColor);
 
       //Set up timer for next shot, and eat any shots that have been missed
       while (w->nextTime <= nowTime) {
@@ -283,7 +282,10 @@ void WorldWeaponGlobalEventHandler::process (bz_EventData *eventData)
   if (capEvent->teamCapped != team)
     return;
 
-  world->getWorldWeapons().fireShot(type, BZDB.eval(StateDatabase::BZDB_RELOADTIME), origin, tilt, direction, -1, NULL, 0);
+  float vec[3] = { 0,0,0 };
+  bz_VectorFromRotations(tilt, direction, vec);
+
+  world->getWorldWeapons().fireShot(type, BZDB.eval(StateDatabase::BZDB_RELOADTIME), origin, vec, -1, NULL, 0);
 }
 
 // Local Variables: ***

--- a/src/bzfs/WorldWeapons.h
+++ b/src/bzfs/WorldWeapons.h
@@ -46,7 +46,7 @@ public:
   int packSize() const;
   void *pack(void *buf) const;
 
-  uint32_t fireShot(FlagType* type, float lifetime, float *pos, float tilt, float direction, float shotSpeed, int *shotID, float delayTime, TeamColor teamColor = RogueTeam, PlayerId targetPlayerID = -1);
+  uint32_t fireShot(FlagType* type, float lifetime, const float origin[3], const float vector[3], float shotSpeed, int *shotID, float delayTime, TeamColor teamColor = RogueTeam, PlayerId targetPlayerID = -1);
 
 private:
   struct Weapon

--- a/src/bzfs/bzfsAPI.cxx
+++ b/src/bzfs/bzfsAPI.cxx
@@ -1721,63 +1721,50 @@ BZF_API bool bz_sentFetchResMessage ( int playerID,  const char* URL )
   return true;
 }
 
-DEPRECATED BZF_API bool bz_fireWorldWep(const char* flagType, float lifetime, int UNUSED(fromPlayer), float *pos, float tilt, float direction, int shotID, float dt, bz_eTeamType shotTeam)
+// old API, many arguments get ingored.
+/*DEPRECATED*/ BZF_API bool bz_fireWorldWep(const char* flagType, float UNUSED(lifetime), int UNUSED(fromPlayer), float *pos, float tilt, float direction, int UNUSED(shotID), float UNUSED(dt), bz_eTeamType shotTeam)
 {
-  if (!pos || !flagType)
+  float v[3] = { 0,0,0 };
+  if (flagType == nullptr || !pos || !bz_VectorFromRotations(tilt, direction, v))
     return false;
 
-  FlagTypeMap &flagMap = FlagType::getFlagMap();
-  if (flagMap.find(std::string(flagType)) == flagMap.end())
+  (int)bz_fireServerShot(flagType, pos, v, shotTeam, -1);
+  return true;
+}
+
+/*DEPRECATED*/ BZF_API bool bz_fireWorldWep(const char* flagType, float UNUSED(lifetime), int UNUSED(fromPlayer), float *pos, float tilt, float direction, float UNUSED(speed), int* shotID, float UNUSED(dt), bz_eTeamType shotTeam)
+{
+  float v[3] = { 0,0,0 };
+  if (flagType == nullptr || !pos || !bz_VectorFromRotations(tilt, direction, v))
     return false;
 
-  FlagType *flag = flagMap.find(std::string(flagType))->second;
-
-  int* realShotID = &shotID;
-  if (shotID == 0)
-    realShotID = NULL;
-
-  return world->getWorldWeapons().fireShot(flag, lifetime, pos, tilt, direction, -1, realShotID, dt, (TeamColor)convertTeam(shotTeam));
+  *shotID = (int)bz_fireServerShot(flagType, pos, v, shotTeam, -1);
+  return true;
 }
 
-DEPRECATED BZF_API bool bz_fireWorldWep(const char* flagType, float lifetime, int UNUSED(fromPlayer), float *pos, float tilt, float direction, float speed, int* shotID, float dt, bz_eTeamType shotTeam)
+/*DEPRECATED*/ BZF_API bool bz_fireWorldWep(const char* flagType, float UNUSED(lifetime), int UNUSED(fromPlayer), float *pos, float tilt, float direction, int* shotID, float UNUSED(dt), bz_eTeamType shotTeam)
 {
-  if (!pos || !flagType)
+  float v[3] = { 0,0,0 };
+  if (flagType == nullptr || !pos || !bz_VectorFromRotations(tilt, direction, v))
     return false;
 
-  FlagTypeMap &flagMap = FlagType::getFlagMap();
-  if (flagMap.find(std::string(flagType)) == flagMap.end())
-    return false;
-
-  FlagType *flag = flagMap.find(std::string(flagType))->second;
-
-  return world->getWorldWeapons().fireShot(flag, lifetime, pos, tilt, direction, speed, shotID, dt, (TeamColor)convertTeam(shotTeam));
+  *shotID = (int)bz_fireServerShot(flagType, pos, v, shotTeam,-1);
+  return true;
 }
 
-DEPRECATED BZF_API bool bz_fireWorldWep(const char* flagType, float lifetime, int UNUSED(fromPlayer), float *pos, float tilt, float direction, int* shotID, float dt, bz_eTeamType shotTeam)
+/*DEPRECATED*/ BZF_API int bz_fireWorldGM(int targetPlayerID, float UNUSED(lifetime), float *pos, float tilt, float direction, float UNUSED(dt), bz_eTeamType shotTeam)
 {
-  return bz_fireWorldWep(flagType, lifetime, ServerPlayer, pos, tilt, direction, -1, shotID, dt, shotTeam);
+  float v[3] = { 0,0,0 };
+  if (!pos || !bz_VectorFromRotations(tilt, direction, v))
+    return -1;
+
+  return (int)bz_fireServerShot("GM", pos, v, shotTeam, targetPlayerID);
 }
 
-DEPRECATED BZF_API int bz_fireWorldGM(int targetPlayerID, float lifetime, float *pos, float tilt, float direction, float dt, bz_eTeamType shotTeam)
-{
-  if (!pos)
-    return false;
+float GetShotLifetime(FlagType* flagType);
 
-  int* shotID = NULL;
-  bz_fireWorldWep("GM", lifetime, ServerPlayer, pos, tilt, direction, -1, shotID, dt, shotTeam);
-
-  return *shotID;
-}
-
-BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float lookAtVector[3], bz_eTeamType color, int targetPlayerId)
-{
-  float tilt = asinf(lookAtVector[3]);
-  float direction = atan2f(lookAtVector[0], lookAtVector[1]);
-
-  return bz_fireServerShot(shotType, lifetime, origin, tilt, direction, color, targetPlayerId);
-}
-
-BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float origin[3], float tilt, float direction, bz_eTeamType color, int targetPlayerId)
+// new API, much cleaner
+BZF_API uint32_t bz_fireServerShot(const char* shotType, float origin[3], float vector[3], bz_eTeamType color, int targetPlayerId)
 {
   if (!shotType || !origin)
     return false;
@@ -1790,88 +1777,88 @@ BZF_API uint32_t bz_fireServerShot(const char* shotType, float lifetime, float o
 
   FlagType *flag = flagMap.find(flagType)->second;
 
-  return world->getWorldWeapons().fireShot(flag, lifetime, origin, tilt, direction, -1, NULL, 0, (TeamColor)convertTeam(color), targetPlayerId);
+  float lifetime = GetShotLifetime(flag);
+
+  return world->getWorldWeapons().fireShot(flag, lifetime, origin, vector, -1, nullptr, 0, (TeamColor)convertTeam(color), targetPlayerId);
 }
 
-BZF_API const bz_ApiString bz_getShotMetaData(const uint32_t shotGUID, const char* name)
+// math helpers
+BZF_API bool bz_VectorFromPoints(const float p1[3], const float p2[3], float outVec[3])
 {
-  if (shotGUID == 0 || shotGUID == NULL || name == NULL)
-    return NULL;
+  float t = 0;
+  for (int i = 0; i < 3; i++)
+    t += pow(p1[i] - p2[i], 2);
 
-  Shots::ShotRef shot = ShotManager.FindShot(shotGUID);
-  std::string key = name;
+  if (abs(t) < 0.00001)
+    return false;
 
-  if (shot->stringMetaData.find(key) == shot->stringMetaData.end())
-    return NULL;
+  float dist = sqrt(t);
 
-  return bz_ApiString(shot->stringMetaData[key]);
+  for (int i = 0; i < 3; i++)
+    outVec[i] = (p1[i] - p2[i]) / dist;
+
+  return true;
 }
 
-BZF_API bool bz_hasShotMetaData(const uint32_t shotGUID, const char* name)
+BZF_API bool bz_VectorFromRotations(const float tilt, const float rotation, float outVec[3])
 {
-  if (shotGUID == 0 || shotGUID == NULL || name == NULL)
-    return NULL;
+  const float tiltFactor = cosf(tilt);
+  
+  outVec[0] = tiltFactor * cosf(rotation);
+  outVec[1] = tiltFactor * sinf(rotation);
+  outVec[2] = sinf(tilt);
+  
+  return true;
+}
 
+// shot meta data
+BZF_API void bz_setShotMetaData(const uint32_t shotGUID, const char* name, uint32_t value)
+{
   Shots::ShotRef shot = ShotManager.FindShot(shotGUID);
-  std::string key = name;
+  if (shot == nullptr || name == nullptr)
+    return;
 
-  return (shot->stringMetaData.find(key) == shot->stringMetaData.end());
+  shot->SetMetaData(std::string(name), value);
 }
 
 BZF_API void bz_setShotMetaData(const uint32_t shotGUID, const char* name, const char* value)
 {
-  if (shotGUID == 0 || shotGUID == NULL || name == NULL)
-    return;
-
   Shots::ShotRef shot = ShotManager.FindShot(shotGUID);
-  std::string key = name;
-
-  shot->stringMetaData[key] = std::string(value);
-}
-
-BZF_API uint32_t bz_getShotMetaData (int fromPlayer, int shotID, const char* name)
-{
-  uint32_t shotGUId = ShotManager.FindShotGUID(fromPlayer,shotID);
-
-  if (shotGUId == 0 || name == NULL)
-    return 0;
-
-  Shots::ShotRef shot = ShotManager.FindShot(shotGUId);
-
-  std::string n = name;
-  if (shot->intMetaData.find(n) == shot->intMetaData.end())
-    return 0;
-
-  return shot->intMetaData[n];
-}
-
-BZF_API void bz_setShotMetaData (int fromPlayer, int shotID, const char* name, uint32_t value)
-{
-  uint32_t shotGUId = ShotManager.FindShotGUID(fromPlayer,shotID);
-
-  if (shotGUId == 0 || name == NULL)
+  if (shot == nullptr || name == nullptr)
     return;
 
-  Shots::ShotRef shot = ShotManager.FindShot(shotGUId);
+  std::string v;
+  if (value != nullptr)
+    v = value;
 
-  std::string n = name;
-  shot->intMetaData[n] = value;
+  shot->SetMetaData(std::string(name), v.c_str());
 }
 
-BZF_API bool bz_shotHasMetaData (int fromPlayer, int shotID, const char* name)
+BZF_API bool bz_shotHasMetaData(const uint32_t shotGUID, const char* name)
 {
-  uint32_t shotGUId = ShotManager.FindShotGUID(fromPlayer,shotID);
-
-  if (shotGUId == 0 || name == NULL)
+  Shots::ShotRef shot = ShotManager.FindShot(shotGUID);
+  if (shot == nullptr || name == nullptr)
     return false;
 
-  Shots::ShotRef shot = ShotManager.FindShot(shotGUId);
+  return shot->HasMetaData(std::string(name));
+}
 
-  std::string n = name;
-  if (shot->intMetaData.find(n) == shot->intMetaData.end())
-    return false;
+BZF_API uint32_t bz_getShotMetaDataI(const uint32_t shotGUID, const char* name)
+{
+  Shots::ShotRef shot = ShotManager.FindShot(shotGUID);
+  if (shot == nullptr || name == nullptr)
+    return 0;
 
-  return true;
+  return shot->GetMetaDataI(std::string(name));
+}
+
+BZF_API const char* bz_getShotMetaDataS(const uint32_t shotGUID, const char* name)
+{
+  Shots::ShotRef shot = ShotManager.FindShot(shotGUID);
+  if (shot == nullptr || name == nullptr)
+    return nullptr;
+
+  return shot->GetMetaDataS(std::string(name));
 }
 
 BZF_API uint32_t bz_getShotGUID (int fromPlayer, int shotID)


### PR DESCRIPTION
add utility functions to convert old angles or targets into a vector.
remove ability for API to override shot params so players can expect consistent behavior from shots.
extend shot meta data to include strings.